### PR TITLE
feat: add client functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .env
-faucet-keypair.json
+faucet_keypair.json
+user_keypair.json

--- a/.idea/cody_history.xml
+++ b/.idea/cody_history.xml
@@ -74,6 +74,42 @@
               <chat>
                 <internalId value="a4a838a9-0260-45d3-a0b9-f6fab305250d" />
               </chat>
+              <chat>
+                <internalId value="b84fc5ed-1b9f-4ce3-8154-733db0c1de57" />
+              </chat>
+              <chat>
+                <internalId value="896bf640-0fc8-4938-a0a3-8ac2cd5942f6" />
+              </chat>
+              <chat>
+                <internalId value="d32c0bb5-ac3b-43b1-8c18-e0723aaab433" />
+              </chat>
+              <chat>
+                <internalId value="311aabae-1738-4d79-a23a-e9d5285fa96f" />
+              </chat>
+              <chat>
+                <internalId value="73bfed7a-0a32-40b7-a6eb-a544661dfb7b" />
+              </chat>
+              <chat>
+                <internalId value="4dfc4ee5-6433-416e-9bcd-59ceee5e4c75" />
+              </chat>
+              <chat>
+                <internalId value="9d1d5e8b-e5a7-4cf2-88eb-968085b93580" />
+              </chat>
+              <chat>
+                <internalId value="798bd118-3a54-4ffd-8a0a-0b82fc6ff174" />
+              </chat>
+              <chat>
+                <internalId value="43eb3875-d3f1-469f-8328-61cb96abbd22" />
+              </chat>
+              <chat>
+                <internalId value="57d89974-b0b1-4a64-8cac-01492bccc665" />
+              </chat>
+              <chat>
+                <internalId value="0775af2e-80ea-40a4-ba18-9cdb3c630140" />
+              </chat>
+              <chat>
+                <internalId value="14b31e3b-4f9f-4405-8834-51f3a58e0c16" />
+              </chat>
             </list>
           </chats>
         </AccountData>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base58"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
+
+[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3393,8 +3399,10 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 name = "simple_token_faucet"
 version = "0.1.0"
 dependencies = [
+ "base58",
  "borsh 1.5.1",
  "getrandom 0.1.16",
+ "solana-client",
  "solana-program",
  "solana-program-test",
  "solana-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "simple_token_faucet"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+name = "client"
+path = "src/client/main.rs"
+
 [lib]
 crate-type = ["cdylib", "lib"]
 
@@ -11,6 +15,9 @@ test-bpf = []
 
 [dependencies]
 solana-program = "2.0.7"
+solana-sdk = "2.0.7"
+solana-client = "2.0.7"
+base58 = "0.2.0"
 borsh = "1.5.1"
 
 [dev-dependencies]

--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -1,0 +1,207 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_client::rpc_client::RpcClient;
+use solana_sdk::{
+    instruction::{AccountMeta, Instruction},
+    native_token::lamports_to_sol,
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    signer::keypair::{read_keypair_file, write_keypair_file},
+    sysvar,
+    transaction::Transaction,
+};
+use std::str::FromStr;
+
+#[derive(BorshSerialize, BorshDeserialize, Debug)]
+enum FaucetInstruction {
+    Initialize { distribution_amount: u64 },
+    RequestTokens,
+    ReplenishTokens { amount: u64 },
+}
+
+fn main() {
+    let rpc_url = "https://api.devnet.solana.com".to_string();
+    let client = RpcClient::new(rpc_url);
+
+    let raw_program_id = "5gpW17UnnPPzgdhdoHBBJM75fmZaCvX14DjvtxqXsqCY";
+    let program_id = Pubkey::from_str(raw_program_id).expect("Failed to parse program ID");
+
+    let faucet_keypair =
+        read_keypair_file("faucet_keypair.json").expect("Failed to read faucet keypair");
+
+    // Check faucet balance before processing
+    check_faucet_balance(&client, &faucet_keypair.pubkey(), 1).expect("Faucet balance is too low");
+
+    // Initialize faucet (comment out once initialized)
+    initialize_faucet(
+        &client,
+        &program_id,
+        &faucet_keypair,
+        &faucet_keypair,
+        100_000_000,
+    );
+
+    // Request tokens from the faucet
+    request_tokens(&client, &program_id, &faucet_keypair);
+
+    // Replenish token
+    replenish_tokens(
+        &client,
+        &program_id,
+        &faucet_keypair,
+        &faucet_keypair,
+        100_000_000,
+    );
+}
+
+fn initialize_faucet(
+    client: &RpcClient,
+    program_id: &Pubkey,
+    faucet_keypair: &Keypair,
+    admin_keypair: &Keypair,
+    distribution_amount: u64,
+) {
+    let instruction = Instruction::new_with_borsh(
+        *program_id,
+        &FaucetInstruction::Initialize {
+            distribution_amount,
+        },
+        vec![
+            AccountMeta::new(faucet_keypair.pubkey(), false),
+            AccountMeta::new(admin_keypair.pubkey(), true),
+            AccountMeta::new_readonly(sysvar::rent::id(), true),
+        ],
+    );
+
+    let recent_blockhash = client.get_latest_blockhash().unwrap();
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&admin_keypair.pubkey()),
+        &[admin_keypair],
+        recent_blockhash,
+    );
+
+    let signature = client.send_and_confirm_transaction(&transaction).unwrap();
+    println!("Faucet initialized. Transaction signature: {}", signature);
+}
+
+fn request_tokens(client: &RpcClient, program_id: &Pubkey, faucet_keypair: &Keypair) {
+    let user_keypair = generate_and_save_keypair();
+    println!("User keypair pubkey: {}", user_keypair.pubkey());
+
+    let instruction = Instruction::new_with_borsh(
+        *program_id,
+        &FaucetInstruction::RequestTokens,
+        vec![
+            AccountMeta::new(faucet_keypair.pubkey(), false),
+            AccountMeta::new(user_keypair.pubkey(), false),
+        ],
+    );
+
+    let recent_blockhash = client.get_latest_blockhash().unwrap();
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&user_keypair.pubkey()),
+        &[&user_keypair],
+        recent_blockhash,
+    );
+
+    let signature = client.send_and_confirm_transaction(&transaction).unwrap();
+    println!("Transaction signature: {}", signature);
+
+    let faucet_balance = client.get_balance(&faucet_keypair.pubkey()).unwrap();
+    println!(
+        "Faucet current balance: {} lamports ({} SOL)",
+        faucet_balance,
+        lamports_to_sol(faucet_balance)
+    );
+
+    let user_balance = client.get_balance(&user_keypair.pubkey()).unwrap();
+    println!(
+        "User current balance: {} lamports ({} SOL)",
+        user_balance,
+        lamports_to_sol(user_balance)
+    );
+
+    let transaction_url = format!(
+        "https://explorer.solana.com/tx/{}?cluster=devnet",
+        signature
+    );
+    println!("Transaction URL: {}", transaction_url);
+}
+
+fn replenish_tokens(
+    client: &RpcClient,
+    program_id: &Pubkey,
+    faucet_keypair: &Keypair,
+    admin_keypair: &Keypair,
+    amount: u64,
+) {
+    let instruction = Instruction::new_with_borsh(
+        *program_id,
+        &FaucetInstruction::ReplenishTokens { amount },
+        vec![
+            AccountMeta::new(faucet_keypair.pubkey(), false),
+            AccountMeta::new(admin_keypair.pubkey(), true),
+        ],
+    );
+
+    let blockhash = client.get_latest_blockhash().unwrap();
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&admin_keypair.pubkey()),
+        &[admin_keypair],
+        blockhash,
+    );
+
+    let signature = client.send_and_confirm_transaction(&transaction).unwrap();
+    println!("Transaction replenished. Signature: {}", signature);
+
+    let balance = client.get_balance(&faucet_keypair.pubkey()).unwrap();
+    println!(
+        "Faucet balance: {} lamports ({} SOL)",
+        balance,
+        lamports_to_sol(balance)
+    );
+}
+
+fn generate_and_save_keypair() -> Keypair {
+    let file_path = "user_keypair.json";
+
+    if !std::path::Path::new(file_path).exists() {
+        println!("Keypair file does not exist, creating one!");
+
+        let user_keypair = Keypair::new();
+        write_keypair_file(&user_keypair, file_path).expect("Failed to write keypair to file");
+
+        println!("Keypair saved to user_keypair.json!");
+        user_keypair
+    } else {
+        println!("Keypair file already exists");
+        read_keypair_file(file_path).expect("Failed to read keypair file")
+    }
+}
+
+// Check the SOL balance in the faucet account
+fn check_faucet_balance(
+    client: &RpcClient,
+    faucet_pubkey: &Pubkey,
+    min_balance: u32,
+) -> Result<(), String> {
+    let faucet_balance = client.get_balance(&faucet_pubkey).unwrap_or(0);
+    let balance_in_sol = lamports_to_sol(faucet_balance);
+
+    if balance_in_sol < min_balance as f64 {
+        return Err(format!(
+            "Faucet balance is too low. Current balance: {} SOL, Minimum required: {} SOL",
+            balance_in_sol, min_balance,
+        ));
+    }
+
+    println!(
+        "Faucet current balance: {} lamports ({} SOL)",
+        faucet_balance,
+        lamports_to_sol(faucet_balance)
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
**Context**
- This PR introduces the client functionality for the simple faucet token project imported from its standalone project and merged with the simple faucet program.

**Changes**
- Created a `client` folder to contain the files required for the faucet token client.
- Added a bin to the `Cargo.toml` file specifying the `main.rs` as the binary target's entrypoint.